### PR TITLE
Reduce code duplication in db.cpp, use builtin formatting in spdlog when logging, remove unnecessary usages of empty C-strings

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,13 +5,6 @@
 #include "config.h"
 #include "misc_functions.h"
 
-confval::confval() {
-	bool_val = 0;
-	uint_val = 0;
-	str_val = "";
-	val_type = CONF_NONEXISTENT;
-}
-
 confval::confval(bool value) {
 	bool_val = value;
 	val_type = CONF_BOOL;
@@ -51,7 +44,6 @@ void confval::set(const std::string &value) {
 
 config::config() {
 	init();
-	dummy_setting = new confval(); // Safety value to use if we're accessing nonexistent settings
 }
 
 void config::init() {
@@ -79,13 +71,13 @@ void config::init() {
 	// MySQL
 	add("mysql_db", "gazelle");
 	add("mysql_host", "localhost");
-	add("mysql_username", "");
-	add("mysql_password", "");
+	add("mysql_username", std::string());
+	add("mysql_password", std::string());
 
 	// Site communication
 	add("site_host", "127.0.0.1");
 	add("site_service", "http");
-	add("site_path", "");
+	add("site_path", std::string());
 	add("site_password", "00000000000000000000000000000000");
 	add("report_password", "00000000000000000000000000000000");
 
@@ -101,7 +93,7 @@ confval * config::get(const std::string &setting_name) {
 	const auto setting = settings.find(setting_name);
 	if (setting == settings.end()) {
 		 spdlog::get("logger")->info("WARNING: Unrecognized setting '" + setting_name + "'");
-		return dummy_setting;
+		return &dummy_setting;
 	}
 	return &setting->second;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -92,7 +92,7 @@ void config::init() {
 confval * config::get(const std::string &setting_name) {
 	const auto setting = settings.find(setting_name);
 	if (setting == settings.end()) {
-		 spdlog::get("logger")->info("WARNING: Unrecognized setting '" + setting_name + "'");
+		 spdlog::get("logger")->info("WARNING: Unrecognized setting '{}'", setting_name);
 		return &dummy_setting;
 	}
 	return &setting->second;
@@ -135,7 +135,7 @@ void config::reload() {
 	const std::string conf_file_path(get_str("conf_file_path"));
 	std::ifstream conf_file(conf_file_path);
 	if (conf_file.fail()) {
-		spdlog::get("logger")->error("Config file '" + conf_file_path + "' couldn't be opened");
+		spdlog::get("logger")->error("Config file '{}' couldn't be opened", conf_file_path);
 	} else {
 		init();
 		load(conf_file);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -71,13 +71,13 @@ void config::init() {
 	// MySQL
 	add("mysql_db", "gazelle");
 	add("mysql_host", "localhost");
-	add("mysql_username", std::string());
-	add("mysql_password", std::string());
+	add("mysql_username", "");
+	add("mysql_password", "");
 
 	// Site communication
 	add("site_host", "127.0.0.1");
 	add("site_service", "http");
-	add("site_path", std::string());
+	add("site_path", "");
 	add("site_password", "00000000000000000000000000000000");
 	add("report_password", "00000000000000000000000000000000");
 

--- a/src/config.h
+++ b/src/config.h
@@ -6,17 +6,17 @@
 
 class confval {
 	private:
-		bool bool_val;
-		uint32_t uint_val;
+		bool bool_val = false;
+		uint32_t uint_val = 0;
 		std::string str_val;
 		enum {
 			CONF_NONEXISTENT,
 			CONF_BOOL,
 			CONF_UINT,
 			CONF_STR,
-		} val_type;
+		} val_type = CONF_NONEXISTENT;
 	public:
-		confval();
+		confval() = default;
 		confval(bool value);
 		confval(uint32_t value);
 		confval(const char * value);
@@ -33,7 +33,7 @@ class config {
 		void init();
 		confval * get(const std::string &setting_name);
 		std::map<std::string, confval> settings;
-		confval * dummy_setting;
+		confval dummy_setting; // Safety value to use if we're accessing nonexistent settings
 	public:
 		config();
 		void load(std::istream &conf_file);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -476,7 +476,7 @@ void mysql::do_flush_torrents() {
 		while (torrent_queue.size() > 0) {
 			try {
 				std::string sql = torrent_queue.front();
-				if (sql == "") {
+				if (sql.empty()) {
 					torrent_queue.pop();
 					continue;
 				}

--- a/src/db.h
+++ b/src/db.h
@@ -11,13 +11,28 @@
 
 class mysql {
 	private:
+		class query_buffer {
+			std::string buf;
+		public:
+			query_buffer() {}
+			query_buffer& operator+=(const std::string& chars) {
+				if (!buf.empty()) {
+					buf += ',';
+				}
+				buf += chars;
+				return *this;
+			}
+			void clear() { buf.clear(); }
+			bool empty() const { return buf.empty(); }
+			const std::string& str() const { return buf; }
+		};
 		mysqlpp::Connection conn;
-		std::string update_user_buffer;
-		std::string update_torrent_buffer;
-		std::string update_heavy_peer_buffer;
-		std::string update_light_peer_buffer;
-		std::string update_snatch_buffer;
-		std::string update_token_buffer;
+		query_buffer update_user_buffer;
+		query_buffer update_torrent_buffer;
+		query_buffer update_heavy_peer_buffer;
+		query_buffer update_light_peer_buffer;
+		query_buffer update_snatch_buffer;
+		query_buffer update_token_buffer;
 
 		std::queue<std::string> user_queue;
 		std::queue<std::string> torrent_queue;

--- a/src/db.h
+++ b/src/db.h
@@ -62,11 +62,7 @@ class mysql {
 		void load_config(config * conf);
 		void load_tokens(torrent_list &torrents);
 
-		void do_flush_users();
-		void do_flush_torrents();
-		void do_flush_snatches();
-		void do_flush_peers();
-		void do_flush_tokens();
+		void do_flush(std::queue<std::string> &queue, std::mutex &mtx, bool &active);
 
 		void flush_users();
 		void flush_torrents();

--- a/src/db.h
+++ b/src/db.h
@@ -13,19 +13,23 @@ class mysql {
 	private:
 		class query_buffer {
 			std::string buf;
+			const mysql &db;
 		public:
-			query_buffer() {}
+			query_buffer(const mysql& db_):db(db_) {}
 			query_buffer& operator+=(const std::string& chars) {
-				if (!buf.empty()) {
-					buf += ',';
+				if (!db.readonly) {
+					if (!buf.empty()) {
+						buf += ',';
+					}
+					buf += chars;
 				}
-				buf += chars;
 				return *this;
 			}
 			void clear() { buf.clear(); }
 			bool empty() const { return buf.empty(); }
 			const std::string& str() const { return buf; }
 		};
+		friend class query_buffer;
 		mysqlpp::Connection conn;
 		query_buffer update_user_buffer;
 		query_buffer update_torrent_buffer;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -50,7 +50,7 @@ void connection_mother::reload_config(config * conf) {
 	unsigned int old_max_connections = max_connections;
 	load_config(conf);
 	if (old_listen_port != listen_port) {
-		logger->info("Changing listen port from " + std::to_string(old_listen_port) +" to " + std::to_string(listen_port));
+		logger->info("Changing listen port from {} to {}", old_listen_port, listen_port);
 		int new_listen_socket = create_listen_socket();
 		if (new_listen_socket != 0) {
 			listen_event.stop();
@@ -73,7 +73,7 @@ int connection_mother::create_listen_socket() {
 	// Stop old sockets from hogging the port
 	int yes = 1;
 	if (setsockopt(new_listen_socket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
-		logger->error("Could not reuse socket: " + std::string(strerror(errno)));
+		logger->error("Could not reuse socket: {}", strerror(errno));
 		return 0;
 	}
 
@@ -85,24 +85,24 @@ int connection_mother::create_listen_socket() {
 
 	// Bind
 	if (bind(new_listen_socket, (sockaddr *) &address, sizeof(address)) == -1) {
-		logger->error("Bind failed: " + std::string(strerror(errno)));
+		logger->error("Bind failed: {}", strerror(errno));
 		return 0;
 	}
 
 	// Listen
 	if (listen(new_listen_socket, max_connections) == -1) {
-		logger->error("Listen failed: " + std::string(strerror(errno)));
+		logger->error("Listen failed: {}", strerror(errno));
 		return 0;
 	}
 
 	// Set non-blocking
 	int flags = fcntl(new_listen_socket, F_GETFL);
 	if (flags == -1) {
-		logger->error("Could not get socket flags: " + std::string(strerror(errno)));
+		logger->error("Could not get socket flags: {}", strerror(errno));
 		return 0;
 	}
 	if (fcntl(new_listen_socket, F_SETFL, flags | O_NONBLOCK) == -1) {
-		logger->error("Could not set non-blocking: " + std::string(strerror(errno)));
+		logger->error("Could not set non-blocking: {}", strerror(errno));
 		return 0;
 	}
 
@@ -110,7 +110,7 @@ int connection_mother::create_listen_socket() {
 }
 
 void connection_mother::run() {
-	logger->info("Sockets up on port " + std::to_string(listen_port) + ", starting event loop!");
+	logger->info("Sockets up on port {}, starting event loop!", listen_port);
 	ev_loop(ev_default_loop(0), 0);
 }
 
@@ -137,7 +137,7 @@ connection_middleman::connection_middleman(int &listen_socket, worker * new_work
 	auto logger = spdlog::get("logger");
 	connect_sock = accept(listen_socket, NULL, NULL);
 	if (connect_sock == -1) {
-		logger->error("Accept failed, errno " + std::to_string(errno) + ": " + std::string(strerror(errno)));
+		logger->error("Accept failed, errno {}: {}", errno, strerror(errno));
 		delete this;
 		return;
 	}

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -56,26 +56,3 @@ std::string hex_decode(const std::string &in) {
 	}
 	return out;
 }
-
-std::string bintohex(const std::string &in) {
-	std::string out;
-	size_t length = in.length();
-	out.reserve(2*length);
-	for (unsigned int i = 0; i < length; i++) {
-		unsigned char x = static_cast<unsigned char>((in[i] & 0xF0) >> 4);
-		if (x > 9) {
-			x += 'a' - 10;
-		} else {
-			x += '0';
-		}
-		out.push_back(x);
-		x = in[i] & 0x0F;
-		if (x > 9) {
-			x += 'a' - 10;
-		} else {
-			x += '0';
-		}
-		out.push_back(x);
-	}
-	return out;
-}

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -6,6 +6,5 @@ int32_t strtoint32(const std::string& str);
 int64_t strtoint64(const std::string& str);
 std::string inttostr(int i);
 std::string hex_decode(const std::string &in);
-std::string bintohex(const std::string &in);
 
 #endif

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -10,7 +10,7 @@
 std::string report(params_type &params, user_list &users_list, client_opts_t &client_opts) {
 	std::stringstream output;
 	std::string action = params["get"];
-	if (action == "") {
+	if (action.empty()) {
 		output << "Invalid action\n";
 	} else if (action == "stats") {
 		time_t uptime = time(NULL) - stats.start_time;

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -31,9 +31,9 @@ void schedule::handle(ev::timer &watcher, int events_flags) {
 	stats.connection_rate = (stats.opened_connections - last_opened_connections) / cur_schedule_interval;
 	stats.request_rate = (stats.requests - last_request_count) / cur_schedule_interval;
 	if (counter % 20 == 0) {
-		logger->info(std::to_string(stats.open_connections) + " open, "
-		+ std::to_string(stats.opened_connections) + " connections (" + std::to_string(stats.connection_rate) + "/s), "
-		+ std::to_string(stats.requests) + " requests (" + std::to_string(stats.request_rate) + "/s)");
+		logger->info("{} open, {} connections ({}/s), {} requests ({}/s)",
+					 stats.open_connections, stats.opened_connections, stats.connection_rate,
+					 stats.requests, stats.request_rate);
 	}
 
 	if (work->get_status() == CLOSING && db->all_clear() && sc->all_clear()) {

--- a/src/site_comm.cpp
+++ b/src/site_comm.cpp
@@ -38,7 +38,7 @@ bool site_comm::all_clear() {
 void site_comm::expire_token(int torrent, int user) {
 	std::stringstream token_pair;
 	token_pair << user << ':' << torrent;
-	if (expire_token_buffer != "") {
+	if (!expire_token_buffer.empty()) {
 		expire_token_buffer += ",";
 	}
 	expire_token_buffer += token_pair.str();
@@ -63,7 +63,7 @@ void site_comm::flush_tokens()
 	if (verbose_flush || qsize > 0) {
 		logger->info("Token expire queue size: " + std::to_string(qsize));
 	}
-	if (expire_token_buffer == "") {
+	if (expire_token_buffer.empty()) {
 		return;
 	}
 	token_queue.push(expire_token_buffer);

--- a/src/site_comm.cpp
+++ b/src/site_comm.cpp
@@ -61,7 +61,7 @@ void site_comm::flush_tokens()
 	std::lock_guard<std::mutex> lock(expire_queue_lock);
 	size_t qsize = token_queue.size();
 	if (verbose_flush || qsize > 0) {
-		logger->info("Token expire queue size: " + std::to_string(qsize));
+		logger->info("Token expire queue size: {}", qsize);
 	}
 	if (expire_token_buffer.empty()) {
 		return;
@@ -126,11 +126,11 @@ void site_comm::do_flush_tokens()
 				std::lock_guard<std::mutex> lock(expire_queue_lock);
 				token_queue.pop();
 			} else {
-				logger->error("Response returned with status code " + std::to_string(status_code) + " when trying to expire a token!");
+				logger->error("Response returned with status code {} when trying to expire a token!", status_code);
 			}
 		}
 	} catch (std::exception &er) {
-		logger->error("Exception: " + std::string(er.what()));
+		logger->error("Exception: {}", er.what());
 	}
 	t_active = false;
 }

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -477,7 +477,7 @@ std::string worker::announce(const std::string &input, torrent &tor, user_ptr &u
 	if (inserted || port != p->port || ip != p->ip) {
 		p->port = port;
 		p->ip = ip;
-		p->ip_port = "";
+		p->ip_port.clear();
 		char x = 0;
 		for (size_t pos = 0, end = ip.length(); pos < end; pos++) {
 			if (ip[pos] == '.') {
@@ -515,7 +515,7 @@ std::string worker::announce(const std::string &input, torrent &tor, user_ptr &u
 		std::string record_str = record.str();
 		std::string record_ip;
 		if (u->is_protected()) {
-			record_ip = "";
+			record_ip.clear();
 		} else {
 			record_ip = ip;
 		}
@@ -550,7 +550,7 @@ std::string worker::announce(const std::string &input, torrent &tor, user_ptr &u
 		std::stringstream record;
 		std::string record_ip;
 		if (u->is_protected()) {
-			record_ip = "";
+			record_ip.empty();
 		} else {
 			record_ip = ip;
 		}
@@ -585,7 +585,7 @@ std::string worker::announce(const std::string &input, torrent &tor, user_ptr &u
 
 				// Find out where to begin in the seeder list
 				peer_list::const_iterator i;
-				if (tor.last_selected_seeder == "") {
+				if (tor.last_selected_seeder.empty()) {
 					i = tor.seeders.begin();
 				} else {
 					i = tor.seeders.find(tor.last_selected_seeder);
@@ -793,7 +793,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 			t->id = static_cast<torid_t>(strtoint32(params["id"]));
 			t->balance = 0;
 			t->completed = 0;
-			t->last_selected_seeder = "";
+			t->last_selected_seeder.clear();
 		} else {
 			t = &i->second;
 		}
@@ -1161,7 +1161,7 @@ std::string worker::get_del_reason(int code)
 			return "Audience Recording";
 			break;
 		default:
-			return "";
+			return std::string();
 			break;
 	}
 }

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <thread>
 #include <spdlog/spdlog.h>
+#include <spdlog/fmt/bin_to_hex.h>
 
 #include "ocelot.h"
 #include "config.h"
@@ -776,11 +777,11 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		std::lock_guard<std::mutex> ul_lock(db->user_list_mutex);
 		auto u = users_list.find(oldpasskey);
 		if (u == users_list.end()) {
-			logger->warn("No user with passkey " + oldpasskey + " exists when attempting to change passkey to " + newpasskey);
+			logger->warn("No user with passkey {} exists when attempting to change passkey to {}", oldpasskey, newpasskey);
 		} else {
 			users_list[newpasskey] = u->second;
 			users_list.erase(oldpasskey);
-			logger->info("Changed passkey from " + oldpasskey + " to " + newpasskey + " for user " + std::to_string(u->second->get_id()));
+			logger->info("Changed passkey from {} to {} for user {}", oldpasskey, newpasskey, u->second->get_id());
 		}
 	} else if (params["action"] == "add_torrent") {
 		torrent *t;
@@ -804,7 +805,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		} else {
 			t->free_torrent = NEUTRAL;
 		}
-		logger->info("Added torrent " + std::to_string(t->id) + ". FL: " + std::to_string(t->free_torrent) + " " + params["freetorrent"]);
+		logger->info("Added torrent {}. FL: {} {}", t->id, t->free_torrent, params["freetorrent"]);
 	} else if (params["action"] == "update_torrent") {
 		std::string info_hash = params["info_hash"];
 		info_hash = hex_decode(info_hash);
@@ -820,9 +821,9 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		auto torrent_it = torrents_list.find(info_hash);
 		if (torrent_it != torrents_list.end()) {
 			torrent_it->second.free_torrent = fl;
-			logger->info("Updated torrent " + std::to_string(torrent_it->second.id) + " to FL " + std::to_string(fl));
+			logger->info("Updated torrent {} to FL {}", torrent_it->second.id, fl);
 		} else {
-			logger->warn("Failed to find torrent " + std::string(info_hash) + " to FL " + std::to_string(fl));
+			logger->warn("Failed to find torrent {} to FL {}", info_hash, fl);
 		}
 	} else if (params["action"] == "update_torrents") {
 		// Each decoded infohash is exactly 20 characters long.
@@ -842,9 +843,9 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 			auto torrent_it = torrents_list.find(info_hash);
 			if (torrent_it != torrents_list.end()) {
 				torrent_it->second.free_torrent = fl;
-				logger->info("Updated torrent " + std::to_string(torrent_it->second.id) + " to FL " + std::to_string(fl));
+				logger->info("Updated torrent {} to FL {}", torrent_it->second.id, fl);
 			} else {
-				logger->warn("Failed to find torrent " + info_hash + " to FL " + std::to_string(fl));
+				logger->warn("Failed to find torrent {} to FL {}", info_hash, fl);
 			}
 		}
 	} else if (params["action"] == "add_token") {
@@ -855,7 +856,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		if (torrent_it != torrents_list.end()) {
 			torrent_it->second.tokened_users.insert(userid);
 		} else {
-			logger->warn("Failed to find torrent to add a token for user " + std::to_string(userid));
+			logger->warn("Failed to find torrent to add a token for user {}", userid);
 		}
 	} else if (params["action"] == "remove_token") {
 		std::string info_hash = hex_decode(params["info_hash"]);
@@ -865,7 +866,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		if (torrent_it != torrents_list.end()) {
 			torrent_it->second.tokened_users.erase(userid);
 		} else {
-			logger->warn("Failed to find torrent " + info_hash + " to remove token for user " + std::to_string(userid));
+			logger->warn("Failed to find torrent {} to remove token for user {}", info_hash, userid);
 		}
 	} else if (params["action"] == "delete_torrent") {
 		std::string info_hash = params["info_hash"];
@@ -878,7 +879,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		std::lock_guard<std::mutex> tl_lock(db->torrent_list_mutex);
 		auto torrent_it = torrents_list.find(info_hash);
 		if (torrent_it != torrents_list.end()) {
-			logger->info("Deleting torrent " + std::to_string(torrent_it->second.id) + " for the reason '" + get_del_reason(reason) + "'");
+			logger->info("Deleting torrent {} for the reason '{}'", torrent_it->second.id, get_del_reason(reason));
 			stats.leechers -= torrent_it->second.leechers.size();
 			stats.seeders -= torrent_it->second.seeders.size();
 			for (auto &p: torrent_it->second.leechers) {
@@ -894,7 +895,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 			del_reasons[info_hash] = msg;
 			torrents_list.erase(torrent_it);
 		} else {
-			logger->warn("Failed to find torrent " + bintohex(info_hash) + " to delete ");
+			logger->warn("Failed to find torrent {} to delete", spdlog::to_hex(info_hash));
 		}
 	} else if (params["action"] == "add_user") {
 		std::string passkey = params["passkey"];
@@ -905,9 +906,9 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 			bool protect_ip = params["visible"] == "0";
 			user_ptr tmp_user = std::make_shared<user>(userid, true, protect_ip);
 			users_list.insert(std::pair<std::string, user_ptr>(passkey, tmp_user));
-			logger->info("Added user " + passkey + " with id " + std::to_string(userid));
+			logger->info("Added user {} with id {}", passkey, userid);
 		} else {
-			logger->warn("Tried to add already known user " + passkey + " with id " + std::to_string(userid));
+			logger->warn("Tried to add already known user {} with id {}", passkey, userid);
 			u->second->set_deleted(false);
 		}
 	} else if (params["action"] == "remove_user") {
@@ -915,7 +916,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		std::lock_guard<std::mutex> ul_lock(db->user_list_mutex);
 		auto u = users_list.find(passkey);
 		if (u != users_list.end()) {
-			logger->info("Removed user " + passkey + " with id " + std::to_string(u->second->get_id()));
+			logger->info("Removed user {} with id {}", passkey, u->second->get_id());
 			u->second->set_deleted(true);
 			users_list.erase(u);
 		}
@@ -927,7 +928,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 			std::string passkey = passkeys.substr(pos, 32);
 			auto u = users_list.find(passkey);
 			if (u != users_list.end()) {
-				logger->info("Removed user " + passkey);
+				logger->info("Removed user {}", passkey);
 				u->second->set_deleted(true);
 				users_list.erase(passkey);
 			}
@@ -945,17 +946,17 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 		std::lock_guard<std::mutex> ul_lock(db->user_list_mutex);
 		user_list::iterator i = users_list.find(passkey);
 		if (i == users_list.end()) {
-			logger->warn("No user with passkey " + passkey + " found when attempting to change leeching status!");
+			logger->warn("No user with passkey {} found when attempting to change leeching status!", passkey);
 		} else {
 			i->second->set_protected(protect_ip);
 			i->second->set_leechstatus(can_leech);
-			logger->info("Updated user " + passkey);
+			logger->info("Updated user {}", passkey);
 		}
 	} else if (params["action"] == "add_whitelist") {
 		std::string peer_id = params["peer_id"];
 		std::lock_guard<std::mutex> wl_lock(db->whitelist_mutex);
 		whitelist.push_back(peer_id);
-		logger->info("Whitelisted " + peer_id);
+		logger->info("Whitelisted {}", peer_id);
 	} else if (params["action"] == "remove_whitelist") {
 		std::string peer_id = params["peer_id"];
 		std::lock_guard<std::mutex> wl_lock(db->whitelist_mutex);
@@ -965,7 +966,7 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 				break;
 			}
 		}
-		logger->info("De-whitelisted " + peer_id);
+		logger->info("De-whitelisted {}", peer_id);
 	} else if (params["action"] == "edit_whitelist") {
 		std::string new_peer_id = params["new_peer_id"];
 		std::string old_peer_id = params["old_peer_id"];
@@ -977,23 +978,23 @@ std::string worker::update(params_type &params, client_opts_t &client_opts) {
 			}
 		}
 		whitelist.push_back(new_peer_id);
-		logger->info("Edited whitelist item from " + old_peer_id + " to " + new_peer_id);
+		logger->info("Edited whitelist item from {} to {}", old_peer_id, new_peer_id);
 	} else if (params["action"] == "update_announce_interval") {
 		const std::string interval = params["new_announce_interval"];
 		conf->set("announce_interval", interval);
 		announce_interval = conf->get_uint("announce_interval");
-		logger->info("Edited announce interval to " + std::to_string(announce_interval));
+		logger->info("Edited announce interval to {}", announce_interval);
 	} else if (params["action"] == "info_torrent") {
 		std::string info_hash_hex = params["info_hash"];
 		std::string info_hash = hex_decode(info_hash_hex);
-		logger->info("Info for torrent '" + std::string(info_hash_hex) + "'");
+		logger->info("Info for torrent '{}'", info_hash_hex);
 		std::lock_guard<std::mutex> tl_lock(db->torrent_list_mutex);
 		auto torrent_it = torrents_list.find(info_hash);
 		if (torrent_it != torrents_list.end()) {
-			logger->info("Torrent " + std::to_string(torrent_it->second.id)
-				+ ", freetorrent = " + std::to_string(torrent_it->second.free_torrent));
+			logger->info("Torrent {}, freetorrent = {}",
+						 torrent_it->second.id, torrent_it->second.free_torrent);
 		} else {
-			logger->warn("Failed to find torrent " + info_hash_hex);
+			logger->warn("Failed to find torrent {}", info_hash_hex);
 		}
 	}
 	return response("success", client_opts);
@@ -1065,8 +1066,8 @@ void worker::reap_peers() {
 		stats.leechers -= reaped_l;
 		stats.seeders -= reaped_s;
 	}
-	logger->info("Reaped " + std::to_string(reaped_l) + " leechers and " + std::to_string(reaped_s)
-				 + " seeders. Reset " + std::to_string(cleared_torrents) + " torrents");
+	logger->info("Reaped {} leechers and {} seeders. Reset {} torrents",
+				 reaped_l, reaped_s, cleared_torrents);
 }
 
 void worker::reap_del_reasons()
@@ -1085,7 +1086,7 @@ void worker::reap_del_reasons()
 		}
 		++it;
 	}
-	logger->info("Reaped " + std::to_string(reaped) + " del reasons");
+	logger->info("Reaped {} del reasons", reaped);
 }
 
 std::string worker::get_del_reason(int code)


### PR DESCRIPTION
`db.cpp` had some very repetitive code related to managing the query buffers. This is now handled by a local wrapper for `std::string` which provides the necessary functionality.
Also, usages of `""` were replaced with equivalent functionality provided by `std::string` member functions where applicable, mostly in context of object construction (where it was completely removed, as the default constructor does the same thing) and checking if a string is empty.