### PR TITLE
Small CMakeLists.txt cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -march=native -O2 -fvisibility=hidden -fvisibility-inlines-hidden -fomit-frame-pointer -fno-ident -Wall -Wfatal-errors")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wfatal-errors")
 
 message(STATUS "CMAKE_MODULE_PATH='${CMAKE_MODULE_PATH}'")
 find_package(Jemalloc)
@@ -66,12 +66,10 @@ SET(LINK_LIBRARIES
 
 if (USE_JEMALLOC)
     message(STATUS "Build with jemalloc")
-    list(APPEND ${LINK_LIBRARIES} ${JEMALLOC_LIBRARY})
-    SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -ljemalloc")
+    list(APPEND LINK_LIBRARIES ${JEMALLOC_LIBRARY})
 elseif (USE_TCMALLOC)
     message(STATUS "Build with tcmalloc")
-    list(APPEND ${LINK_LIBRARIES} ${TCMALLOC_LIBRARY})
-    SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -ltcmalloc")
+    list(APPEND LINK_LIBRARIES ${TCMALLOC_LIBRARY})
 endif()
 
 target_link_libraries(


### PR DESCRIPTION
CMakeLists.txt currently sets optimisation flags regardless of the build type, which makes creating debug builds difficult. Release builds, with optimisation enabled, are ordinarily created by setting `CMAKE_BUILD_TYPE` to `Release`, for example via passing `-DCMAKE_BUILD_TYPE=Release` in the commandline, which causes the appropriate optimisation flags to be passed. These currently evaluate to `-O3 -DNDEBUG` on my system, but may be further modified by setting `CMAKE_CXX_FLAGS_RELEASE` if need be.
Furthermore :
* `-std=c++11` is already taken care of by setting `CMAKE_CXX_STANDARD` to `11`. However, currently this will cause `-std=gnu++11` to be added to the flags on GCC since [`CMAKE_CXX_EXTENSIONS`](https://cmake.org/cmake/help/v3.12/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS) defaults to true.
* `-march=native` causes the builds to be made for the CPU that the build host is running, which can enable better optimisations but might make the resulting binary unportable between different systems. As such, it should only be added when building the binary to run on the current host and only on the current host, on a case-by-case basis.
* `-fvisibility=hidden` and `-fvisibility-inlines-hidden` are generally used when building shared libraries and require the usage of [visibility pragmas/attributes](https://gcc.gnu.org/wiki/Visibility) to actually do anything, but since they're harmless (and perhaps might cause the compiler to produce a binary smaller in size due to not emitting all symbols, though that's quite far-fetched), I chose to leave them here.
* `-fomit-frame-pointer` is [enabled by default at all optimisation levels](https://gcc.gnu.org/onlinedocs/gcc-9.3.0/gcc/Optimize-Options.html#index-fomit-frame-pointer), so it does not make sense to spell it out explicitly.
* `-fno-ident` is by far the most interesting one, and I have to admit it's probably the first time ever that I see this flag. According to [the documentation](https://gcc.gnu.org/onlinedocs/gcc-9.3.0/gcc/Code-Gen-Options.html#index-fno-ident), it only ignores the `#ident` directive, which is supposed to be a [flag originating from System V](https://gcc.gnu.org/onlinedocs/cpp/Other-Directives.html). I have no idea where it came from, and this directive is not used throughout the code at all, so I see no reason to keep this flag.

Also, the unnecessary modification of `CMAKE_EXE_LINKER_FLAGS` was removed - there is generally little reason to modify this variable, and any external library references for linking should be passed to `target_link_libraries` instead. I guess the reason for the confusion was the invalid invocation of list append, since it passed the expanded value of the `LINK_LIBRARIES` variable instead of the list name itself.