### PR TITLE
Implement logging SQL queries

### DIFF
--- a/ocelot.conf.dist
+++ b/ocelot.conf.dist
@@ -19,6 +19,8 @@ mysql_host          =
 mysql_username      = 
 mysql_password      = 
 mysql_db            = 
+# All queries are written to this file, if writable. Will be created if necessary.
+mysql_query_dump    = /tmp/ocelot.sql
 
 # The passwords must be 32 characters and match the Gazelle config
 report_password     = 00000000000000000000000000000000

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -81,6 +81,7 @@ void config::init() {
 	add("mysql_host", "localhost");
 	add("mysql_username", "");
 	add("mysql_password", "");
+	add("mysql_query_dump", "");
 
 	// Site communication
 	add("site_host", "127.0.0.1");

--- a/src/db.h
+++ b/src/db.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <queue>
 #include <mutex>
+#include <fstream>
 #include "config.h"
 
 class mysql {
@@ -56,6 +57,11 @@ class mysql {
 		void flush_tokens();
 		void clear_peer_data();
 
+		mysqlpp::Query do_query(mysqlpp::Connection&, const std::string&);
+		mysqlpp::Query do_query(const std::string &sql) {
+			return do_query(conn, sql);
+		}
+
 	public:
 		bool verbose_flush;
 
@@ -80,6 +86,9 @@ class mysql {
 		std::mutex torrent_list_mutex;
 		std::mutex user_list_mutex;
 		std::mutex whitelist_mutex;
+
+		std::mutex query_dump_mutex;
+		std::ofstream query_dump;
 };
 
 #pragma GCC visibility pop


### PR DESCRIPTION
Implement logging for the SQL queries that Ocelot makes to the database.
Keep in mind that currently there is no way to log the value/status returned by the query. Also, queries are logged regardless of their status, so it's possible for some queries to appear multiple times - this mostly applies to the `INSERT`s made via `do_flush_*` functions. Let me know if some other behaviour is required.