### PR TITLE
Use unordered_set for whitelist lookups

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -5,9 +5,11 @@
 #include <spdlog/spdlog.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <queue>
 #include <mutex>
 #include "config.h"
+#include "ocelot.h"
 
 class mysql {
 	private:
@@ -64,13 +66,13 @@ class mysql {
 		bool connected();
 		void load_torrents(torrent_list &torrents);
 		void load_users(user_list &users);
-		void load_whitelist(std::vector<std::string> &whitelist);
+		void load_whitelist(std::unordered_set<peerid_t> &whitelist);
 
 		void record_user(const std::string &record); // (id,uploaded_change,downloaded_change)
 		void record_torrent(const std::string &record); // (id,seeders,leechers,snatched_change,balance)
 		void record_snatch(const std::string &record, const std::string &ip); // (uid,fid,tstamp)
-		void record_peer(const std::string &record, const std::string &ip, const std::string &peer_id, const std::string &useragent); // (uid,fid,active,peerid,useragent,ip,uploaded,downloaded,upspeed,downspeed,left,timespent,announces,tstamp)
-		void record_peer(const std::string &record, const std::string &peer_id); // (fid,peerid,timespent,announces,tstamp)
+		void record_peer(const std::string &record, const std::string &ip, const peerid_t &peer_id, const std::string &useragent); // (uid,fid,active,peerid,useragent,ip,uploaded,downloaded,upspeed,downspeed,left,timespent,announces,tstamp)
+		void record_peer(const std::string &record, const peerid_t &peer_id); // (fid,peerid,timespent,announces,tstamp)
 		void record_token(const std::string &record);
 
 		void flush();

--- a/src/misc_functions.cpp
+++ b/src/misc_functions.cpp
@@ -25,38 +25,6 @@ std::string inttostr(const int i) {
 	return str;
 }
 
-std::string hex_decode(const std::string &in) {
-	std::string out;
-	out.reserve(20);
-	unsigned int in_length = in.length();
-	for (unsigned int i = 0; i < in_length; i++) {
-		unsigned char x = '0';
-		if (in[i] == '%' && (i + 2) < in_length) {
-			i++;
-			if (in[i] >= 'a' && in[i] <= 'f') {
-				x = static_cast<unsigned char>((in[i]-87) << 4);
-			} else if (in[i] >= 'A' && in[i] <= 'F') {
-				x = static_cast<unsigned char>((in[i]-55) << 4);
-			} else if (in[i] >= '0' && in[i] <= '9') {
-				x = static_cast<unsigned char>((in[i]-48) << 4);
-			}
-
-			i++;
-			if (in[i] >= 'a' && in[i] <= 'f') {
-				x += static_cast<unsigned char>(in[i]-87);
-			} else if (in[i] >= 'A' && in[i] <= 'F') {
-				x += static_cast<unsigned char>(in[i]-55);
-			} else if (in[i] >= '0' && in[i] <= '9') {
-				x += static_cast<unsigned char>(in[i]-48);
-			}
-		} else {
-			x = in[i];
-		}
-		out.push_back(x);
-	}
-	return out;
-}
-
 std::string bintohex(const std::string &in) {
 	std::string out;
 	size_t length = in.length();

--- a/src/misc_functions.h
+++ b/src/misc_functions.h
@@ -1,11 +1,57 @@
 #ifndef MISC_FUNCTIONS__H
 #define MISC_FUNCTIONS__H
 #include <string>
+#include <array>
 
 int32_t strtoint32(const std::string& str);
 int64_t strtoint64(const std::string& str);
 std::string inttostr(int i);
-std::string hex_decode(const std::string &in);
+
+inline std::uint8_t hexchar_to_bin(char in) {
+	auto out = static_cast<std::uint8_t>(in);
+	if (in >= 'a' && in <= 'f') {
+		return out - 'a' + 10;
+	} else if (in >= 'A' && in <= 'F') {
+		return out - 'A' + 10;
+	} else if (in >= '0' && in <= '9') {
+		return out - '0';
+	} else {
+		return '0';
+	}
+}
+
+template<typename Oiter, typename F>
+inline bool hex_decode_impl(const std::string& in, Oiter out, F out_is_end)
+{
+	unsigned int i;
+	for (i = 0; i < in.length() && !out_is_end(out); i++, out++) {
+		unsigned char x = '0';
+		if (in[i] == '%' && (i + 2) < in.length()) {
+			x = (hexchar_to_bin(in[i + 1]) << 4) | hexchar_to_bin(in[i + 2]);
+			i += 2;
+		} else {
+			x = in[i];
+		}
+		*out = x;
+	}
+	return (i == in.length());
+}
+
+template<std::size_t N>
+inline bool hex_decode(std::array<std::uint8_t, N> &out, const std::string &in) {
+	auto end = std::end(out);
+	return hex_decode_impl(in, std::begin(out),
+						[=](typename std::array<std::uint8_t, N>::iterator it) {
+		return it == end; });
+}
+
+inline std::string hex_decode(const std::string &in) {
+	std::string out;
+	out.reserve(20);
+	hex_decode_impl(in, std::back_inserter(out),
+					[](std::back_insert_iterator<std::string>) { return false; });
+	return out;
+}
 std::string bintohex(const std::string &in);
 
 #endif

--- a/src/ocelot.cpp
+++ b/src/ocelot.cpp
@@ -12,6 +12,7 @@
 #include "db.h"
 #include "worker.h"
 #include "events.h"
+#include <unordered_set>
 
 static connection_mother *mother;
 static worker *work;
@@ -157,7 +158,7 @@ int main(int argc, char **argv) {
 
 	user_list users_list;
 	torrent_list torrents_list;
-	std::vector<std::string> whitelist;
+	std::unordered_set<peerid_t> whitelist;
 	db->load_users(users_list);
 	db->load_torrents(torrents_list);
 	db->load_whitelist(whitelist);

--- a/src/worker.h
+++ b/src/worker.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <list>
 #include <unordered_map>
+#include <unordered_set>
 #include <iostream>
 #include <mutex>
 #include <ctime>
@@ -21,7 +22,7 @@ class worker {
 		site_comm * s_comm;
 		torrent_list &torrents_list;
 		user_list &users_list;
-		std::vector<std::string> &whitelist;
+		std::unordered_set<peerid_t> &whitelist;
 		std::unordered_map<std::string, del_message> del_reasons;
 		tracker_status status;
 		bool reaper_active;
@@ -46,7 +47,7 @@ class worker {
 		inline bool peer_is_visible(user_ptr &u, peer *p);
 
 	public:
-		worker(config * conf_obj, torrent_list &torrents, user_list &users, std::vector<std::string> &_whitelist, mysql * db_obj, site_comm * sc);
+		worker(config * conf_obj, torrent_list &torrents, user_list &users, std::unordered_set<peerid_t> &_whitelist, mysql * db_obj, site_comm * sc);
 		void reload_config(config * conf);
 		std::string work(const std::string &input, std::string &ip, client_opts_t &client_opts);
 		std::string announce(const std::string &input, torrent &tor, user_ptr &u, params_type &params, params_type &headers, std::string &ip, client_opts_t &client_opts);

--- a/test/whitelist.pl
+++ b/test/whitelist.pl
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Readonly;
+use Test::More;
+use Convert::Bencode qw(bencode bdecode);
+use LWP::UserAgent();
+
+Readonly::Scalar my $ocelot_host => 'localhost';
+Readonly::Scalar my $ocelot_port => 34000;
+
+sub make_request {
+    my ( $endpoint, $passkey, $params ) = @_;
+    my $h   = LWP::UserAgent->new();
+    my $req = URI->new(
+        "http://${ocelot_host}:${ocelot_port}/" . "${passkey}/${endpoint}" );
+    $req->query_form( %{$params} );
+    my $rsp = $h->get( $req, %{$params} );
+    ok( $rsp->is_success, 'http response is ok' );
+    return $rsp->decoded_content;
+}
+
+sub make_site_request {
+    my $params = shift;
+    Readonly::Scalar my $site_password => '0' x 32;
+    my $content = make_request( 'update', $site_password, $params );
+    is( $content, 'success', 'site request successful' );
+    return;
+}
+
+Readonly::Scalar my $passkey   => 'x' x 32;
+Readonly::Scalar my $info_hash => 'a' x 40;
+Readonly::Scalar my $peer_id   => 'A' x 20;
+
+sub make_announce {
+    my $reply = make_request( 'announce', $passkey,
+        { info_hash => $info_hash, peer_id => $peer_id, compact => 1 } );
+    return bdecode($reply);
+}
+
+make_site_request( { action => 'add_user', passkey => $passkey, id => 9000 } );
+make_site_request(
+    { action => 'add_torrent', info_hash => $info_hash, id => 42 } );
+make_site_request( { action => 'add_whitelist', peer_id => $peer_id } );
+
+my $reply = make_announce();
+is( $reply->{downloaded}, 0, 'announce accepted' );
+
+my $new_peer_id = ( $peer_id =~ s/A/B/gr );
+make_site_request(
+    {
+        action      => 'edit_whitelist',
+        old_peer_id => $peer_id,
+        new_peer_id => $new_peer_id
+    }
+);
+
+$reply = make_announce();
+is(
+    $reply->{'failure reason'},
+    'Your client is not on the whitelist',
+    'announce rejected'
+);
+
+make_site_request(
+    {
+        action  => 'remove_whitelist',
+        peer_id => $new_peer_id
+    }
+);
+
+$reply = make_announce();
+is( $reply->{downloaded}, 0, 'announce accepted' );
+
+done_testing();
+
+exit 0;


### PR DESCRIPTION
All whitelist lookups are currently performed by a linear search over a `std::vector` of `std::string` objects. Since peer IDs are always 20 bytes long, an `std::array` might be better suited for this, and has the added advantage of always storing the data contiguously, which is not a requirement with `std::string`s. Storing such `std::array`s in an `unordered_set` gives a clear performance advantage, as illustrated in [this benchmark](https://gist.github.com/undertheironbridge/ae6372138e52cc73e4bf6a80c202084f).

Since whitelist lookups need to be made for every announce, I suppose this might have a very positive impact on the overall performance of the tracker.